### PR TITLE
chore: FCS de18d8b2d (patch 7.55) + dependency bumps (9.1.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout (with submodules)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       # is fully initialised; fetch-depth: 0 keeps full history for any version
       # scripts that inspect git tags.
       - name: Checkout (with submodules)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive

--- a/Sharlayan/NLog.xsd
+++ b/Sharlayan/NLog.xsd
@@ -4591,6 +4591,7 @@
           <xs:element name="maxRecursionLimit" type="xs:integer" minOccurs="0" maxOccurs="1" default="1" />
           <xs:element name="renderEmptyObject" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
           <xs:element name="suppressSpaces" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeActivityIds" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
           <xs:element name="includeScopes" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
           <xs:element name="state" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.JsonAttribute" />
           <xs:element name="timestampFormat" type="xs:string" minOccurs="0" maxOccurs="1" default="o" />
@@ -4643,6 +4644,11 @@
         <xs:attribute name="suppressSpaces" type="xs:boolean">
           <xs:annotation>
             <xs:documentation>Option to suppress the extra spaces in the output json.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeActivityIds" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include "TraceId" + "SpanId" + "ParentId" from P:System.Diagnostics.Activity.Current</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="includeScopes" type="xs:boolean">

--- a/Sharlayan/Sharlayan.csproj
+++ b/Sharlayan/Sharlayan.csproj
@@ -15,7 +15,8 @@
 		<RepositoryUrl></RepositoryUrl>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageTags>ffxiv memory tracking</PackageTags>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<!-- Release-only: Debug builds run in tight loops and the nuspec/nupkg writes race antivirus file locks -->
+		<GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
 		<Company>SyndicatedLife</Company>
 		<Product>Sharlayan</Product>
 		<Description>Final Fantasy XIV Memory Reading</Description>
@@ -51,12 +52,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Lumina" Version="7.5.0" />
-		<PackageReference Include="Lumina.Excel" Version="7.4.3" />
+		<PackageReference Include="Lumina" Version="7.6.1" />
+		<PackageReference Include="Lumina.Excel" Version="7.5.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="NLog" Version="6.1.3" />
-		<PackageReference Include="NLog.Schema" Version="6.1.3" />
-		<PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.45" PrivateAssets="all" />
+		<PackageReference Include="NLog" Version="6.1.4" />
+		<PackageReference Include="NLog.Schema" Version="6.1.4" />
+		<PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.46" PrivateAssets="all" />
 	</ItemGroup>
 
 	<!-- Test-only access for internal members (e.g. MapLanguage in Reader.Lumina.cs).
@@ -116,14 +117,25 @@
 			<InputAssemblies Include="$(OutputPath)InteropGenerator.Runtime.dll" />
 			<DoNotInternalizeAssemblies Include="Sharlayan" />
 		</ItemGroup>
+		<!--
+		    Merge into an intermediate file, then Copy with retries into bin. Writing
+		    $(OutputPath)Sharlayan.dll in place races antivirus scanners that briefly lock
+		    the file csc just wrote — ILRepack's temp-file move has no retry and fails the
+		    build. The Copy task retries until the scanner releases the lock.
+		-->
 		<ILRepack
 			Parallel="true"
 			Internalize="true"
 			InternalizeExclude="@(DoNotInternalizeAssemblies)"
 			InputAssemblies="@(InputAssemblies)"
-			OutputFile="$(OutputPath)Sharlayan.dll"
+			OutputFile="$(IntermediateOutputPath)ilrepack\Sharlayan.dll"
 			TargetKind="Dll"
 			LibraryPath="$(OutputPath)" />
+		<Copy
+			SourceFiles="$(IntermediateOutputPath)ilrepack\Sharlayan.dll"
+			DestinationFiles="$(OutputPath)Sharlayan.dll"
+			Retries="30"
+			RetryDelayMilliseconds="1000" />
 	</Target>
 
 	<Target Name="CopyPackages" AfterTargets="Pack">

--- a/Sharlayan/version.props
+++ b/Sharlayan/version.props
@@ -5,7 +5,7 @@
          Patch: incremented by Claude/AI on each substantive code change to Sharlayan. -->
     <VersionMajor>9</VersionMajor>
     <VersionMinor>1</VersionMinor>
-    <VersionPatch>2</VersionPatch>
+    <VersionPatch>3</VersionPatch>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Derived version strings — do not edit these directly. -->


### PR DESCRIPTION
FFXIV shipped patch 7.55, so this pulls FFXIVClientStructs forward from 15ae1806b to de18d8b2d. The runtime-reflection design did its job: zero source changes needed. The build compiles clean against the new structs and all 195 integrity tests pass unchanged, which means every scanner key, mapper field, and FieldOffsetReader lookup still resolves.

This also folds in the five open dependabot PRs (#118, #120, #121, #122, #123). They all edit the same csproj block and would conflict merged one at a time, so the bumps land here as one change: Lumina 7.6.1, Lumina.Excel 7.5.0, NLog 6.1.4, NLog.Schema 6.1.4, ILRepack.Lib.MSBuild.Task 2.0.46, and actions/checkout v7 in both workflows. The Lumina bump matters for 7.55 sqpack reads; the rest are routine patches. Dependabot will close its PRs once this merges. NLog.xsd is the schema file NLog.Schema 6.1.4 drops into the project.

Two build fixes came out of fighting antivirus file locks during this session. ILRepack used to merge into bin\Sharlayan.dll in place - when a scanner held the file it just written, the merge died with no retry. It now merges into obj and a Copy task with 30 retries moves it to bin. NuGet pack is Release-only now, since packing on every Debug build added two more lockable files per compile for no benefit.
