### PR TITLE
chore: stop tracked generated files churning the working tree

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,14 @@
 # conversion noise.
 * text=auto eol=lf
 
+# Tracked files that a Windows tool regenerates with CRLF on every build:
+# NLog.xsd is dropped by the NLog.Schema package on restore, Sharlayan.xml is
+# emitted by csc. Under the blanket eol=lf above they showed as modified after
+# every build with no content change. Stored LF, checked out CRLF so the
+# working copy matches what the generators write and `git status` stays clean.
+Sharlayan/NLog.xsd     text eol=crlf
+Sharlayan/Sharlayan.xml text eol=crlf
+
 # Custom for Visual Studio
 *.cs     diff=csharp
 *.sln    merge=union


### PR DESCRIPTION
Two tracked files are regenerated on every Windows build — `NLog.xsd` by the NLog.Schema package on restore, `Sharlayan.xml` by csc — and both come out with CRLF. The repo's blanket `* text=auto eol=lf` rule means git then reports them modified after every single build, with no content change at all.

That's mostly an annoyance, but it's the kind that costs you eventually: `git status` is never clean, so real edits sit next to permanent noise and it's easy to either commit the churn or miss something.

Both files now check out as CRLF, matching what the generators actually write. The stored blobs stay LF, so CI and any Linux checkout are unaffected. Getting an existing working copy clean needs one re-checkout of `NLog.xsd` (delete it and `git checkout --`), since the attribute only applies on checkout — after that it stays clean on its own.

Verified locally: full `build.ps1` run plus 208 tests leave the tree clean.

Noticed while doing post-merge cleanup after #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
